### PR TITLE
Replace instance of React.PropTypes with PropTypes

### DIFF
--- a/es6/PropTypes.js
+++ b/es6/PropTypes.js
@@ -1,7 +1,7 @@
 'use strict';
 
 export { falsy };
-import { PropTypes } from 'react';
+import PropTypes from 'prop-types';
 
 var func = PropTypes.func;
 var object = PropTypes.object;

--- a/lib/PropTypes.js
+++ b/lib/PropTypes.js
@@ -3,15 +3,19 @@
 exports.__esModule = true;
 exports.falsy = falsy;
 
-var _react = require('react');
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
-var func = _react.PropTypes.func;
-var object = _react.PropTypes.object;
-var arrayOf = _react.PropTypes.arrayOf;
-var oneOfType = _react.PropTypes.oneOfType;
-var element = _react.PropTypes.element;
-var shape = _react.PropTypes.shape;
-var string = _react.PropTypes.string;
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+var func = _propTypes2['default'].func;
+var object = _propTypes2['default'].object;
+var arrayOf = _propTypes2['default'].arrayOf;
+var oneOfType = _propTypes2['default'].oneOfType;
+var element = _propTypes2['default'].element;
+var shape = _propTypes2['default'].shape;
+var string = _propTypes2['default'].string;
 
 function falsy(props, propName, componentName) {
   if (props[propName]) return new Error('<' + componentName + '> should not have a "' + propName + '" prop');

--- a/modules/PropTypes.js
+++ b/modules/PropTypes.js
@@ -1,4 +1,4 @@
-import { PropTypes } from 'react'
+import PropTypes from 'prop-types'
 
 const { func, object, arrayOf, oneOfType, element, shape, string } = PropTypes
 


### PR DESCRIPTION
There was one last use of `React.PropTypes` left.